### PR TITLE
neg: Fix longstanding bug with neg windows

### DIFF
--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -196,7 +196,7 @@ getNegFragmentFunction (CompScreen  *s,
 	if (alpha)
 	    ok &= addDataOpToFunctionData (data,
 			"MUL output.rgb, output.a, output;");
-		
+
 	ok &= addColorOpToFunctionData (data, "output", "output");
 	if (!ok)
 	{
@@ -549,11 +549,9 @@ static void
 NEGWindowAdd (CompScreen *s,
 	      CompWindow *w)
 {
-    NEG_SCREEN (s);
-
     /* nw->isNeg is initialized to FALSE in InitWindow, so we only
        have to toggle it to TRUE if necessary */
-    if (ns->isNeg && matchEval (negGetNegMatch (s), w))
+    if (matchEval (negGetNegMatch (s), w))
 	NEGToggle (w);
 }
 
@@ -830,5 +828,4 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
-
 


### PR DESCRIPTION
No way of automatically negating specific windows when they start.
This fixes the Neg Windows option so it does just that.
Thanks Scott Moreau for the help.
This bug fix will save my Eyes, my Screen, and my Power Bill.
