### PR TITLE
Negative: improvements to window matching

### DIFF
--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -23,19 +23,14 @@
 		</display>
 		<screen>
 			<option name="neg_match" type="match">
-				<_short>Auto-toggle windows</_short>
-				<_long>Windows to be made negative when opened</_long>
+				<_short>Always-negative windows</_short>
+				<_long>Windows to always start out negative</_long>
 				<default></default>
 			</option>
 			<option name="exclude_match" type="match">
 				<_short>Exclude windows</_short>
 				<_long>Windows to exclude from negating</_long>
 				<default>type=Desktop</default>
-			</option>
-			<option name="default_enabled" type="bool">
-				<_short>Enable by default</_short>
-				<_long>Enable full-screen negative automatically</_long>
-				<default>false</default>
 			</option>
 		</screen>
 	</plugin>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -23,14 +23,19 @@
 		</display>
 		<screen>
 			<option name="neg_match" type="match">
-				<_short>Neg Windows</_short>
-				<_long>Windows to be negative by default</_long>
-				<default>any</default>
+				<_short>Auto-toggle windows</_short>
+				<_long>Windows to be made negative when opened</_long>
+				<default></default>
 			</option>
 			<option name="exclude_match" type="match">
-				<_short>Exclude Windows</_short>
+				<_short>Exclude windows</_short>
 				<_long>Windows to exclude from negating</_long>
 				<default>type=Desktop</default>
+			</option>
+			<option name="default_enabled" type="bool">
+				<_short>Enable by default</_short>
+				<_long>Enable full-screen negative automatically</_long>
+				<default>false</default>
 			</option>
 		</screen>
 	</plugin>

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -570,16 +570,26 @@ NEGScreenOptionChanged (CompScreen       *s,
 
 	    for (w = s->windows; w; w = w->next)
 	    {
-		Bool isNeg;
+		Bool m; // Matches negative
+		Bool e; // Matches exclude
+		Bool f; // Screen toggled
+		Bool t; // Window toggled
 		NEG_WINDOW (w);
 
-		isNeg = matchEval (negGetNegMatch (s), w);
-		isNeg = isNeg && !matchEval (negGetExcludeMatch (s), w);
+		m = matchEval (negGetNegMatch (s), w);
+		e = matchEval (negGetExcludeMatch (s), w);
 
-		if (isNeg && ns->isNeg && !nw->isNeg)
+		// Look at the current state and decide whether to negate the window
+		if (t && !(m || e || f)) ||
+		   (f && !(m || e || t)) ||
+		   (m && !(f || e || t)) ||
+		   (e && t && !(m || f)) ||
+		   (m && f && t && !(e)) ||
+		   (m && e && t && !(f)) ||
+		   (m && e && f && t)
+		{
 		    NEGToggle (w);
-		else if (!isNeg && nw->isNeg)
-		    NEGToggle (w);
+		}
 	    }
 	}
 	break;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -573,8 +573,9 @@ NEGScreenOptionChanged (CompScreen       *s,
 	    {
 		Bool isNeg;
 		NEG_WINDOW (w);
+
 		isNeg = matchEval (negGetNegMatch (s), w);
-		isNeg = isNeg || negGetDefaultEnabled(s);
+		isNeg = isNeg || negGetDefaultEnabled (s);
 		isNeg = isNeg && !matchEval (negGetExcludeMatch (s), w);
 
 		if (isNeg && ns->isNeg && !nw->isNeg)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -580,13 +580,15 @@ NEGScreenOptionChanged (CompScreen       *s,
 		e = matchEval (negGetExcludeMatch (s), w);
 
 		// Look at the current state and decide whether to negate the window
-		if (t && !(m || e || f)) ||
-		   (f && !(m || e || t)) ||
-		   (m && !(f || e || t)) ||
-		   (e && t && !(m || f)) ||
-		   (m && f && t && !(e)) ||
-		   (m && e && t && !(f)) ||
-		   (m && e && f && t)
+		if (
+			(t && !(m || e || f)) ||
+			(f && !(m || e || t)) ||
+			(m && !(f || e || t)) ||
+			(e && t && !(m || f)) ||
+			(m && f && t && !(e)) ||
+			(m && e && t && !(f)) ||
+			(m && e && f && t)
+		   )
 		{
 		    NEGToggle (w);
 		}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -551,7 +551,7 @@ NEGWindowAdd (CompScreen *s,
 {
     /* nw->isNeg is initialized to FALSE in InitWindow, so we only
        have to toggle it to TRUE if necessary */
-    if ( (matchEval (negGetNegMatch (s), w)) || negGetDefaultEnabled(s) )
+    if (matchEval (negGetNegMatch (s), w))
 	NEGToggle (w);
 }
 
@@ -573,8 +573,8 @@ NEGScreenOptionChanged (CompScreen       *s,
 	    {
 		Bool isNeg;
 		NEG_WINDOW (w);
-
 		isNeg = matchEval (negGetNegMatch (s), w);
+		isNeg = isNeg || negGetDefaultEnabled(s);
 		isNeg = isNeg && !matchEval (negGetExcludeMatch (s), w);
 
 		if (isNeg && ns->isNeg && !nw->isNeg)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -551,7 +551,7 @@ NEGWindowAdd (CompScreen *s,
 {
     /* nw->isNeg is initialized to FALSE in InitWindow, so we only
        have to toggle it to TRUE if necessary */
-    if (matchEval (negGetNegMatch (s), w)) || negGetDefaultEnabled(s)
+    if ( (matchEval (negGetNegMatch (s), w)) || negGetDefaultEnabled(s) )
 	NEGToggle (w);
 }
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -578,6 +578,8 @@ NEGScreenOptionChanged (CompScreen       *s,
 
 		m = matchEval (negGetNegMatch (s), w);
 		e = matchEval (negGetExcludeMatch (s), w);
+		f = ns->isNeg;
+		t = nw->isNeg;
 
 		// Look at the current state and decide whether to negate the window
 		if (

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -564,7 +564,6 @@ NEGScreenOptionChanged (CompScreen       *s,
     {
     case NegScreenOptionNegMatch:
     case NegScreenOptionExcludeMatch:
-    case NegScreenOptionDefaultEnabled:
 	{
 	    CompWindow *w;
 	    NEG_SCREEN (s);
@@ -575,7 +574,6 @@ NEGScreenOptionChanged (CompScreen       *s,
 		NEG_WINDOW (w);
 
 		isNeg = matchEval (negGetNegMatch (s), w);
-		isNeg = isNeg || negGetDefaultEnabled (s);
 		isNeg = isNeg && !matchEval (negGetExcludeMatch (s), w);
 
 		if (isNeg && ns->isNeg && !nw->isNeg)
@@ -715,7 +713,6 @@ NEGInitScreen (CompPlugin *p,
 
     negSetNegMatchNotify (s, NEGScreenOptionChanged);
     negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
-    negSetDefaultEnabledNotify (s, NEGScreenOptionChanged);
 
     /* wrap overloaded functions */
     WRAP (ns, s, drawWindowTexture, NEGDrawWindowTexture);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -551,7 +551,7 @@ NEGWindowAdd (CompScreen *s,
 {
     /* nw->isNeg is initialized to FALSE in InitWindow, so we only
        have to toggle it to TRUE if necessary */
-    if (matchEval (negGetNegMatch (s), w))
+    if (matchEval (negGetNegMatch (s), w)) || negGetDefaultEnabled(s)
 	NEGToggle (w);
 }
 
@@ -564,6 +564,7 @@ NEGScreenOptionChanged (CompScreen       *s,
     {
     case NegScreenOptionNegMatch:
     case NegScreenOptionExcludeMatch:
+    case NegScreenOptionDefaultEnabled:
 	{
 	    CompWindow *w;
 	    NEG_SCREEN (s);
@@ -713,6 +714,7 @@ NEGInitScreen (CompPlugin *p,
 
     negSetNegMatchNotify (s, NEGScreenOptionChanged);
     negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
+    negSetDefaultEnabledNotify (s, NEGScreenOptionChanged);
 
     /* wrap overloaded functions */
     WRAP (ns, s, drawWindowTexture, NEGDrawWindowTexture);


### PR DESCRIPTION
This improves the negative plugin's window matching, and improves the wording slightly.

There are, however, two remaining issues that this PR does not resolve, since they seem complicated to fix due to the way the plugin is implemented:

- Window matches specified in ccsm clobber manually toggled windows
- Windows in the exclude list in ccsm cannot be manually toggled

To fix those, I think that the flag for manual toggling needs to be split from the flag for match-based toggling, which seems like a headache.