### PR TITLE
Staticswitcher: Further improvements

### DIFF
--- a/metadata/staticswitcher.xml.in
+++ b/metadata/staticswitcher.xml.in
@@ -99,6 +99,10 @@
 		    <_short>Prev Panel</_short>
 		    <_long>Select previous panel type window.</_long>
 		</option>
+		<option name="close_highlighted_key" type="key">
+		    <_short>Close highlighted</_short>
+		    <_long>Closes the currently highlighted window. If the switcher is not in use, closes the currently active window instead.</_long>
+		</option>
 	    </group>
 	</display>
 	<screen>

--- a/metadata/staticswitcher.xml.in
+++ b/metadata/staticswitcher.xml.in
@@ -166,7 +166,7 @@
 		    <_long>Allow selection of windows from the switcher window with the mouse</_long>
 		    <default>false</default>
 		</option>
-        <option name="mouse_close" type="bool">
+		<option name="mouse_close" type="bool">
 		    <_short>Allow Mouse Close</_short>
 		    <_long>Close window on clicking its preview in the popup with the middle button</_long>
 		    <default>false</default>
@@ -223,6 +223,24 @@
 			<value>2</value>
 			<_name>Right</_name>
 		    </desc>
+		</option>
+		<option name="popup_preview_size" type="int">
+		    <_short>Popup Preview Size</_short>
+		    <_long>Size of the previews in the popup</_long>
+		    <default>150</default>
+		    <min>0</min>
+		</option>
+		<option name="popup_border_size" type="int">
+		    <_short>Popup Border Size</_short>
+		    <_long>Size of the border of the popup</_long>
+		    <default>10</default>
+		    <min>0</min>
+		</option>
+		<option name="popup_icon_size" type="int">
+		    <_short>Icon Size</_short>
+		    <_long>Size of the icon overlays</_long>
+		    <default>48</default>
+		    <min>0</min>
 		</option>
 		<subgroup>
 		    <_short>Selected Window Highlight</_short>
@@ -295,24 +313,6 @@
 			</default>
 		    </option>
 		</subgroup>
-		<option name="popup_preview_size" type="int">
-		    <_short>Popup Preview Size</_short>
-		    <_long>Size of the previews in the popup</_long>
-		    <default>150</default>
-		    <min>0</min>
-		</option>
-		<option name="popup_border_size" type="int">
-		    <_short>Popup Border Size</_short>
-		    <_long>Size of the border of the popup</_long>
-		    <default>10</default>
-		    <min>0</min>
-		</option>
-		<option name="popup_icon_size" type="int">
-		    <_short>Icon Size</_short>
-		    <_long>Size of the icon overlays</_long>
-		    <default>48</default>
-		    <min>0</min>
-		</option>
 	    </group>
 	</screen>
     </plugin>

--- a/src/staticswitcher/staticswitcher.c
+++ b/src/staticswitcher/staticswitcher.c
@@ -1077,6 +1077,44 @@ switchWindowRemove (CompDisplay *d,
     }
 }
 
+static Bool
+switchCloseCurrentWindow (CompDisplay     *d,
+                          CompAction      *action,
+                          CompActionState  state,
+                          CompOption      *option,
+                          int              nOption)
+{
+    CompWindow *selected;
+    Window xid;
+    CompScreen *s;
+
+    xid = getIntOptionNamed (option, nOption, "root", 0);
+    s = findScreenAtDisplay (d, xid);
+    SWITCH_SCREEN (s);
+    if (ss->switching)
+    {
+	if (s)
+	{
+	    selected = ss->selectedWindow;
+	}
+    }
+    else
+    {
+	/* Switcher is not currently in use, so close the current display's active window instead */
+	xid = getIntOptionNamed (option, nOption, "window", 0);
+	selected = findWindowAtDisplay (d, xid);
+    }
+    if (selected)
+    {
+	closeWindow (selected, getCurrentTimeFromDisplay (d));
+	if (selected)
+	{
+	    switchWindowRemove (d, selected);
+	}
+    }
+    return TRUE;
+}
+
 static void
 updateForegroundColor (CompScreen *s)
 {
@@ -2048,6 +2086,7 @@ switchInitDisplay (CompPlugin  *p,
     staticswitcherSetPrevPanelButtonTerminate (d, switchTerminate);
     staticswitcherSetPrevPanelKeyInitiate (d, switchPrevPanel);
     staticswitcherSetPrevPanelKeyTerminate (d, switchTerminate);
+    staticswitcherSetCloseHighlightedKeyInitiate (d, switchCloseCurrentWindow);
 
     sd->selectWinAtom     = XInternAtom (d->display,
 					 DECOR_SWITCH_WINDOW_ATOM_NAME, 0);

--- a/src/staticswitcher/staticswitcher.c
+++ b/src/staticswitcher/staticswitcher.c
@@ -1286,7 +1286,7 @@ switchHandleEvent (CompDisplay *d,
 					closeWindow (selected, getCurrentTimeFromDisplay (d));
 					if (selected)
 					{
-						switchWindowRemove (d, w);
+						switchWindowRemove (d, selected);
 					}
 				}
 			}


### PR DESCRIPTION
- Allow closing the current window using a configurable keyboard shortcut.
- Fix two style errors and one logic error in my code in #21 (none of which have any discernible effect, as far as I can tell).

(The default appearance/behavior should be unaffected by these changes.)