### PR TITLE
shift: Add obs to the "before" relation list

### DIFF
--- a/metadata/shift.xml.in
+++ b/metadata/shift.xml.in
@@ -7,7 +7,6 @@
 		<deps>
 			<relation type="before">
 				<plugin>fade</plugin>
-				<plugin>bs</plugin>
 				<plugin>obs</plugin>
 			</relation>
 			<relation type="after">

--- a/metadata/shift.xml.in
+++ b/metadata/shift.xml.in
@@ -8,6 +8,7 @@
 			<relation type="before">
 				<plugin>fade</plugin>
 				<plugin>bs</plugin>
+				<plugin>obs</plugin>
 			</relation>
 			<relation type="after">
 				<plugin>text</plugin>


### PR DESCRIPTION
...because bs was included in this relation, but has since been renamed, so presumably the obs plugin would not be matched as intended.