### PR TITLE
negative: One bug fix, three new features.

### DIFF
--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -15,12 +15,12 @@
 				<_long>Toggle active window negative</_long>
 				<default>&lt;Super&gt;n</default>
 			</option>
-			<option name="screen_toggle_key" type="key">
+			<option name="new_screen_toggle_key" type="key">
 				<_short>Toggle Screen Negative</_short>
 				<_long>Toggle all windows negative, except for windows in the &quot;Screen Exclusions&quot; list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
-			<option name="matched_toggle_key" type="key">
+			<option name="screen_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
 				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
 				<default></default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -45,7 +45,7 @@
 			<option name="exclude_match" type="match">
 				<_short>Screen Exclusions</_short>
 				<_long>Windows to exclude when toggling the screen.</_long>
-				<default>!(type=Desktop || type=Dock)</default>
+				<default>type=Desktop || type=Dock</default>
 			</option>
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -20,7 +20,7 @@
 				<_long>Toggle all windows negative, except for windows in the &quot;Screen Exclusions&quot; list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
-			<option name="screen_toggle_key" type="key">
+			<option name="screen_toggle_key" type="key"><!-- This option inherits the previous "Toggle Screen Negative"'s behavior when updating from previous configurations, so the name "screen_toggle_key" is used to inherit the keybinding correctly. -->
 				<_short>Toggle Matched Windows Negative</_short>
 				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
 				<default></default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -34,7 +34,7 @@
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
-				<_long>Windows to affect when toggling only matched windows</_long>
+				<_long>Windows to affect when using the &quot;Toggle Matched Windows Negative&quot; keybinding or &quot;Auto-Toggle Matched Windows&quot;</_long>
 				<default>!(type=Desktop)</default>
 			</option>
 			<option name="toggle_screen_by_default" type="bool">
@@ -49,7 +49,7 @@
 			</option>
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
-				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; list, preserve their state when toggling the screen</_long>
+				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen</_long>
 				<default>false</default>
 			</option>
 		</screen>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -52,6 +52,11 @@
 				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen. Note that toggled windows' state will not be preserved between Compiz restarts.</_long>
 				<default>false</default>
 			</option>
+			<option name="clear_toggled" type="bool">
+				<_short>Auto-Clear Toggled Window State</_short>
+				<_long>A window that has been toggled using the &quot;Toggle Windows Negative&quot; keybinding will have its state discarded when toggling a match group that includes that window.</_long>
+				<default>false</default>
+			</option>
 		</screen>
 	</plugin>
 </compiz>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -50,7 +50,7 @@
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
 				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; list, preserve their state when toggling the screen</_long>
-				<default>false</default>
+				<default>true</default>
 			</option>
 		</screen>
 	</plugin>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -17,29 +17,29 @@
 			</option>
 			<option name="screen_toggle_key" type="key">
 				<_short>Toggle Screen Negative</_short>
-				<_long>Toggle all windows negative, except for windows in the Screen Exclusions match list</_long>
+				<_long>Toggle all windows negative, except for windows in the &quot;Screen Exclusions&quot; list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
 			<option name="matched_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
-				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; match list</_long>
+				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
 				<default></default>
 			</option>
 		</display>
 		<screen>
 			<option name="toggle_match_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
-				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default.</_long>
+				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default</_long>
 				<default>true</default>
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
-				<_long>Windows to affect when negating only matched windows.</_long>
+				<_long>Windows to affect when negating only matched windows</_long>
 				<default></default>
 			</option>
 			<option name="toggle_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>
-				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list.</_long>
+				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list</_long>
 				<default>false</default>
 			</option>
 			<option name="exclude_match" type="match">
@@ -49,7 +49,7 @@
 			</option>
 			<option name="toggle_match_by_default" type="bool">
 				<_short>Preserve Toggled Windows</_short>
-				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; set, preserve their state when toggling the screen.</_long>
+				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; list, preserve their state when toggling the screen</_long>
 				<default>false</default>
 			</option>
 		</screen>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -49,7 +49,7 @@
 			</option>
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
-				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen</_long>
+				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen. Note that toggled windows' state will not be preserved between Compiz restarts.</_long>
 				<default>false</default>
 			</option>
 		</screen>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -30,7 +30,7 @@
 			<option name="toggle_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
 				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default</_long>
-				<default>false</default><!-- This default must be kept in sync with the initialization of ns->matchNeg in neg.c. -->
+				<default>false</default>
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
@@ -40,7 +40,7 @@
 			<option name="toggle_screen_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>
 				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list</_long>
-				<default>false</default><!-- This default must be kept in sync with the initialization of ns->isNeg in neg.c. -->
+				<default>false</default>
 			</option>
 			<option name="exclude_match" type="match">
 				<_short>Screen Exclusions</_short>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -55,7 +55,7 @@
 			<option name="clear_toggled" type="bool">
 				<_short>Auto-Clear Toggled Window State</_short>
 				<_long>A window that has been toggled using the &quot;Toggle Windows Negative&quot; keybinding will have its state discarded when toggling a match group that includes that window.</_long>
-				<default>false</default>
+				<default>true</default>
 			</option>
 		</screen>
 	</plugin>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -15,12 +15,12 @@
 				<_long>Toggle active window negative</_long>
 				<default>&lt;Super&gt;n</default>
 			</option>
-			<option name="new_screen_toggle_key" type="key">
+			<option name="screen_toggle_key" type="key">
 				<_short>Toggle Screen Negative</_short>
 				<_long>Toggle all windows negative, except for windows in the &quot;Screen Exclusions&quot; list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
-			<option name="screen_toggle_key" type="key">
+			<option name="matched_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
 				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
 				<default></default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -30,12 +30,12 @@
 			<option name="toggle_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
 				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default</_long>
-				<default>true</default>
+				<default>false</default>
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
 				<_long>Windows to affect when toggling only matched windows</_long>
-				<default></default>
+				<default>!(type=Desktop | type=Dock)</default>
 			</option>
 			<option name="toggle_screen_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>
@@ -50,7 +50,7 @@
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
 				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; list, preserve their state when toggling the screen</_long>
-				<default>true</default>
+				<default>false</default>
 			</option>
 		</screen>
 	</plugin>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -30,7 +30,7 @@
 			<option name="toggle_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
 				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default</_long>
-				<default>false</default>
+				<default>false</default><!-- This default must be kept in sync with the initialization of ns->matchNeg in neg.c. -->
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
@@ -40,7 +40,7 @@
 			<option name="toggle_screen_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>
 				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list</_long>
-				<default>false</default>
+				<default>false</default><!-- This default must be kept in sync with the initialization of ns->isNeg in neg.c. -->
 			</option>
 			<option name="exclude_match" type="match">
 				<_short>Screen Exclusions</_short>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -22,7 +22,7 @@
 			</option>
 			<option name="matched_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
-				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
+				<_long>Toggles the windows negative matched by the &quot;Matched Windows&quot; list</_long>
 				<default></default>
 			</option>
 		</display>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -17,25 +17,40 @@
 			</option>
 			<option name="screen_toggle_key" type="key">
 				<_short>Toggle Screen Negative</_short>
-				<_long>Toggle screen negative</_long>
+				<_long>Toggle all windows negative, except for windows in the Screen Exclusions match list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
 			<option name="matched_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
-				<_long>Toggles windows matched by the &quot;Negative Windows&quot; match field negative</_long>
+				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; match list</_long>
 				<default></default>
 			</option>
 		</display>
 		<screen>
-			<option name="toggle_by_default" type="bool">
+			<option name="toggle_match_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
-				<_long>Automatically toggle windows in the match list by default</_long>
-				<default>false</default>
+				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default.</_long>
+				<default>true</default>
 			</option>
 			<option name="neg_match" type="match">
-				<_short>Negative Windows</_short>
-				<_long>Windows to affect when negating. Use &quot;all&quot; in this field, combined with the &quot;Auto-Toggle Matched Windows&quot; option to have the screen's default state be fully negated.</_long>
-				<default>!(type=Desktop)</default>
+				<_short>Matched Windows</_short>
+				<_long>Windows to affect when negating only matched windows.</_long>
+				<default></default>
+			</option>
+			<option name="toggle_by_default" type="bool">
+				<_short>Auto-Toggle Screen</_short>
+				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list.</_long>
+				<default>false</default>
+			</option>
+			<option name="exclude_match" type="match">
+				<_short>Screen Exclusions</_short>
+				<_long>Windows to exclude when toggling the screen.</_long>
+				<default>!(type=Desktop || type=Dock)</default>
+			</option>
+			<option name="toggle_match_by_default" type="bool">
+				<_short>Preserve Toggled Windows</_short>
+				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; set, preserve their state when toggling the screen.</_long>
+				<default>false</default>
 			</option>
 		</screen>
 	</plugin>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -35,7 +35,7 @@
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
 				<_long>Windows to affect when toggling only matched windows</_long>
-				<default>!(type=Desktop | type=Dock)</default>
+				<default>!(type=Desktop)</default>
 			</option>
 			<option name="toggle_screen_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -34,7 +34,7 @@
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Matched Windows</_short>
-				<_long>Windows to affect when negating only matched windows</_long>
+				<_long>Windows to affect when toggling only matched windows</_long>
 				<default></default>
 			</option>
 			<option name="toggle_screen_by_default" type="bool">

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -27,7 +27,7 @@
 			</option>
 		</display>
 		<screen>
-			<option name="toggle_match_by_default" type="bool">
+			<option name="toggle_by_default" type="bool">
 				<_short>Auto-Toggle Matched Windows</_short>
 				<_long>Automatically toggle windows in the &quot;Matched Windows&quot; list by default</_long>
 				<default>true</default>
@@ -37,7 +37,7 @@
 				<_long>Windows to affect when negating only matched windows</_long>
 				<default></default>
 			</option>
-			<option name="toggle_by_default" type="bool">
+			<option name="toggle_screen_by_default" type="bool">
 				<_short>Auto-Toggle Screen</_short>
 				<_long>Automatically toggle all windows by default, except for those in the &quot;Screen Exclusions&quot; list</_long>
 				<default>false</default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -49,12 +49,12 @@
 			</option>
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
-				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen. Note that toggled windows' state will not be preserved between Compiz restarts.</_long>
+				<_long>When windows have been toggled using the &quot;Toggle Windows Negative&quot; keybinding, preserve their state when toggling the screen. Note that toggled windows' state will not be preserved between Compiz restarts. To use this option, disable &quot;Auto-Clear Toggled Window State&quot;.</_long>
 				<default>false</default>
 			</option>
 			<option name="clear_toggled" type="bool">
 				<_short>Auto-Clear Toggled Window State</_short>
-				<_long>A window that has been toggled using the &quot;Toggle Windows Negative&quot; keybinding will have its state discarded when toggling a match group that includes that window.</_long>
+				<_long>A window that has been toggled using the &quot;Toggle Windows Negative&quot; keybinding will have its state discarded when toggling a match group that includes that window. This will clear window states even if &quot;Preserve Toggled Windows&quot; is selected.</_long>
 				<default>true</default>
 			</option>
 		</screen>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -20,7 +20,7 @@
 				<_long>Toggle all windows negative, except for windows in the &quot;Screen Exclusions&quot; list</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
-			<option name="screen_toggle_key" type="key"><!-- This option inherits the previous "Toggle Screen Negative"'s behavior when updating from previous configurations, so the name "screen_toggle_key" is used to inherit the keybinding correctly. -->
+			<option name="screen_toggle_key" type="key">
 				<_short>Toggle Matched Windows Negative</_short>
 				<_long>Toggles the windows negative matched by the &quot;Negative Windows&quot; list</_long>
 				<default></default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -45,7 +45,7 @@
 			<option name="exclude_match" type="match">
 				<_short>Screen Exclusions</_short>
 				<_long>Windows to exclude when toggling the screen.</_long>
-				<default>type=Desktop || type=Dock</default>
+				<default>type=Desktop | type=Dock</default>
 			</option>
 			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -20,6 +20,11 @@
 				<_long>Toggle screen negative</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
+			<option name="matched_toggle_key" type="key">
+				<_short>Toggle Matched Windows Negative</_short>
+				<_long>Toggles windows matched by the &quot;Negative Windows&quot; match field negative</_long>
+				<default></default>
+			</option>
 		</display>
 		<screen>
 			<option name="toggle_by_default" type="bool">
@@ -29,7 +34,7 @@
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Negative Windows</_short>
-				<_long>Windows to affect when negating</_long>
+				<_long>Windows to affect when negating. Use &quot;all&quot; in this field, combined with the &quot;Auto-Toggle Matched Windows&quot; option to have the screen's default state be fully negated.</_long>
 				<default>!(type=Desktop)</default>
 			</option>
 		</screen>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -47,7 +47,7 @@
 				<_long>Windows to exclude when toggling the screen.</_long>
 				<default>!(type=Desktop || type=Dock)</default>
 			</option>
-			<option name="toggle_match_by_default" type="bool">
+			<option name="preserve_toggled" type="bool">
 				<_short>Preserve Toggled Windows</_short>
 				<_long>When windows have been toggled by themselves or as part of the &quot;Matched Windows&quot; list, preserve their state when toggling the screen</_long>
 				<default>false</default>

--- a/metadata/neg.xml.in
+++ b/metadata/neg.xml.in
@@ -20,11 +20,6 @@
 				<_long>Toggle screen negative</_long>
 				<default>&lt;Super&gt;m</default>
 			</option>
-			<option name="matched_toggle_key" type="key">
-				<_short>Toggle Matched Windows Negative</_short>
-				<_long>Toggles windows matched by the &quot;Negative Windows&quot; match field negative</_long>
-				<default></default>
-			</option>
 		</display>
 		<screen>
 			<option name="toggle_by_default" type="bool">
@@ -34,7 +29,7 @@
 			</option>
 			<option name="neg_match" type="match">
 				<_short>Negative Windows</_short>
-				<_long>Windows to affect when negating. Use &quot;all&quot; in this field, combined with the &quot;Auto-Toggle Matched Windows&quot; option to have the screen's default state be fully negated.</_long>
+				<_long>Windows to affect when negating</_long>
 				<default>!(type=Desktop)</default>
 			</option>
 		</screen>

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -155,30 +155,6 @@ negToggleAll (CompDisplay     *d,
     return TRUE;
 }
 
-static Bool
-negToggleMatched (CompDisplay     *d,
-	      CompAction      *action,
-	      CompActionState state,
-	      CompOption      *option,
-	      int             nOption)
-{
-    CompScreen *s;
-    Window     xid;
-
-    xid = getIntOptionNamed (option, nOption, "root", 0);
-    s = findScreenAtDisplay (d, xid);
-
-    if (s)
-	for (w = s->windows; w; w = w->next)
-	{
-		NEG_WINDOW (w);
-		nw->isNeg = !nw->isNeg;
-		NEGUpdateState (w);
-	}
-
-    return TRUE;
-}
-
 static int
 getNegFragmentFunction (CompScreen  *s,
 			CompTexture *texture,
@@ -728,7 +704,6 @@ NEGInitDisplay (CompPlugin  *p,
 
     negSetWindowToggleKeyInitiate (d, negToggle);
     negSetScreenToggleKeyInitiate (d, negToggleAll);
-    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 
@@ -891,3 +866,4 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
+

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -884,9 +884,9 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg           = FALSE;
+    ns->isNeg           = negGetToggleScreenByDefault (s);
     ns->keyNegToggled   = FALSE;
-    ns->matchNeg        = FALSE;
+    ns->matchNeg        = negGetToggleByDefault (s);
     ns->keyMatchToggled = FALSE;
 
     ns->negFunction      = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -97,8 +97,16 @@ NEGUpdateState (CompWindow *w)
     NEG_SCREEN (s);
     NEG_WINDOW (w);
 
+    Bool windowState;
+
     /* Decide whether the given window should be negative or not, depending on
-       the various parameters that can affect this, and set nw->isNeg thus */
+       the various parameters that can affect this, and set windowState thus */
+
+    windowState = ns->isNeg;
+
+    /* Now that we know what this window's state should be, push the value to
+       its nw->isNeg. */
+    nw->isNeg = windowState;
 
     /* cause repainting */
     addWindowDamage (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -628,7 +628,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = TRUE;
+	    ns->matchNeg = opt[NegScreenOptionToggleMatchByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}
@@ -642,7 +642,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = TRUE;
+	    ns->isNeg = opt[NegScreenOptionToggleByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -102,12 +102,23 @@ NEGUpdateState (CompWindow *w)
 
 	windowState = FALSE;
 
-    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
-	windowState = !windowState;
+    /* Whole screen toggle state */
+    if (! matchEval (negGetExcludeMatch (w->screen), w)) {
+	if (ns->isNeg)
+	    windowState = !windowState;
+	if (ns->keyNegToggled)
+	    windowState = !windowState;
+    }
 
-    if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
-	windowState = !windowState;
+    /* Matched set toggle state */
+    if (matchEval (negGetNegMatch (w->screen), w)) {
+	if (ns->matchNeg)
+	    windowState = !windowState;
+	if (ns->keyMatchToggled)
+	    windowState = !windowState;
+    }
 
+    /* Individual window state */
     if (nw->keyNegToggled)
 	windowState = !windowState;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -471,20 +471,20 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PREVIOUS);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
 
-    		    constant[0] = 0.5f + 0.5f * RED_SATURATION_WEIGHT;
+		    constant[0] = 0.5f + 0.5f * RED_SATURATION_WEIGHT;
 		    constant[1] = 0.5f + 0.5f * GREEN_SATURATION_WEIGHT;
 		    constant[2] = 0.5f + 0.5f * BLUE_SATURATION_WEIGHT;
 		    constant[3] = 1.0;
 
 		    glTexEnvfv (GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, constant);
 
-    		    /* mark another texture active */
+		    /* mark another texture active */
 		    (*w->screen->activeTexture) (GL_TEXTURE2_ARB);
 
 		    /* enable that texture */
-    		    enableTexture (w->screen, texture, filter);
+		    enableTexture (w->screen, texture, filter);
 
-	    	    glTexEnvf (GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
+		    glTexEnvf (GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_INTERPOLATE);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_TEXTURE0);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE1_RGB, GL_PREVIOUS);
@@ -571,7 +571,7 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    /* disable the current texture */
 		    disableTexture (w->screen, texture);
 
-	    	    /* set the texture mode back to replace */
+		    /* set the texture mode back to replace */
 		    glTexEnvi (GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 
 		    /* re-activate last texture */
@@ -582,12 +582,12 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    /* fully saturated or fully unsaturated */
 
 		    glTexEnvf (GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_MODULATE);
-    		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PREVIOUS);
+		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PREVIOUS);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE1_ALPHA, GL_CONSTANT);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
 
-    		    /* color constant */
+		    /* color constant */
 		    constant[3] = attrib->opacity / 65535.0f;
 		    constant[0] = constant[1] = constant[2] =
 				  constant[3] * attrib->brightness / 65535.0f;
@@ -601,7 +601,7 @@ NEGDrawWindowTexture (CompWindow           *w,
 
 		    glTexEnvfv (GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, constant);
 
-    		    /* draw the window geometry */
+		    /* draw the window geometry */
 		    (*w->drawWindowGeometry) (w);
 		}
 
@@ -651,7 +651,7 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    /* enable blending */
 		    glEnable (GL_BLEND);
 
-    		    /* color constant */
+		    /* color constant */
 		    constant[3] = attrib->opacity / 65535.0f;
 		    constant[0] = constant[3] * attrib->brightness / 65535.0f;
 		    constant[1] = constant[3] * attrib->brightness / 65535.0f;
@@ -675,7 +675,7 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
 
-    		    /* draw the window geometry */
+		    /* draw the window geometry */
 		    (*w->drawWindowGeometry) (w);
 
 		    /* disable blending */

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -63,10 +63,13 @@ typedef struct _NEGWindow
 {
     Bool isNeg; /* negative window flag: controlled by NEGUpdateState function */
     Bool keyNegToggled; /* window has been individually toggled using the
-                           "Toggle Window Negative" keybinding */
+                           "Toggle Window Negative" keybinding (will be unset
+                           when Preserve Toggled Windows means the window
+                           should be using its previous state) */
     Bool keyNegPreserved; /* window has been individually toggled using the
-                           "Toggle Window Negative" keybinding, but it is not
-                           active at the moment */
+                           "Toggle Window Negative" keybinding. This preserves
+                           the window state between screen toggles for Preserve
+                           Toggled Windows. */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \
@@ -685,6 +688,8 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleScreenByDefault:
 	{
 	    NEG_SCREEN (s);
+
+	    CompWindow *w;
 
 	    /* update toggle state for relevant windows */
 	    for (w = s->windows; w; w = w->next)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -179,16 +179,17 @@ NEGScreenClearToggled (CompScreen *s)
        (not matched by Screen Exclusions) if the Auto-Clear config option is
        set. */
 
+    if (!negGetClearToggled (s))
+	return;
+
     CompWindow *w;
 
-    if (negGetClearToggled (s)) {
-	for (w = s->windows; w; w = w->next)
-	{
-	    if (! matchEval (negGetExcludeMatch (w->screen), w)) {
-		NEG_WINDOW (w);
-		nw->keyNegToggled = FALSE;
-		nw->keyNegPreserved = FALSE;
-	    }
+    for (w = s->windows; w; w = w->next)
+    {
+	if (! matchEval (negGetExcludeMatch (w->screen), w)) {
+    	NEG_WINDOW (w);
+    	nw->keyNegToggled = FALSE;
+    	nw->keyNegPreserved = FALSE;
 	}
     }
 }
@@ -842,8 +843,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetScreenToggleKeyInitiate  (d, negToggleAll);
-    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
+    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
+    negSetScreenToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -677,6 +677,18 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleByDefault:
 	{
 	    NEG_SCREEN (s);
+	    CompWindow *w;
+
+	    if (negGetClearToggled (s)) {
+		for (w = s->windows; w; w = w->next)
+		{
+		    if (matchEval (negGetNegMatch (w->screen), w)) {
+			NEG_WINDOW (w);
+			nw->keyNegToggled = FALSE;
+			nw->keyNegPreserved = FALSE;
+		    }
+		}
+	    }
 
 	    ns->matchNeg = negGetToggleByDefault (s);
 
@@ -691,6 +703,17 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleScreenByDefault:
 	{
 	    NEG_SCREEN (s);
+
+	    if (negGetClearToggled (s)) {
+		for (w = s->windows; w; w = w->next)
+		{
+		    if (! matchEval (negGetExcludeMatch (w->screen), w)) {
+			NEG_WINDOW (w);
+			nw->keyNegToggled = FALSE;
+			nw->keyNegPreserved = FALSE;
+		    }
+		}
+	    }
 
 	    ns->isNeg = negGetToggleScreenByDefault (s);
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -842,8 +842,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetNewScreenToggleKeyInitiate  (d, negToggleAll); /* "Toggle Screen Negative" in CCSM */
-    negSetScreenToggleKeyInitiate (d, negToggleMatched); /* "Toggle Matched Windows Negative" in CCSM */
+    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
+    negSetScreenToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -612,9 +612,7 @@ static void
 NEGWindowAdd (CompScreen *s,
 	      CompWindow *w)
 {
-	NEG_WINDOW (w);
-
-	/* Run matching logic on this window */
+	/* Run matching logic on the new window */
 	NEGUpdateState (w);
 }
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -933,3 +933,4 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
+

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -137,7 +137,6 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 	nw->keyNegToggled = FALSE;
     else if (negGetPreserveToggled (w->screen) && nw->keyNegPreserved)
 	nw->keyNegToggled = TRUE;
-	nw->keyNegPreserved = FALSE;
 }
 
 static void

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -152,7 +152,7 @@ NEGToggleScreen (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s)))
+	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle screen negative flag */
@@ -169,7 +169,7 @@ NEGToggleMatches (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s)))
+	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle match negative flag */

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -117,6 +117,19 @@ NEGToggleScreen (CompScreen *s)
 	    NEGToggleWindow (w);
 }
 
+static void
+NEGToggleMatches (CompScreen *s)
+{
+    CompWindow *w;
+
+    NEG_SCREEN(s);
+
+    /* toggle matched windows */
+    for (w = s->windows; w; w = w->next)
+	if (w)
+	    NEGUpdateState (w);
+}
+
 static Bool
 negToggle (CompDisplay     *d,
 	   CompAction      *action,
@@ -169,12 +182,7 @@ negToggleMatched (CompDisplay     *d,
     s = findScreenAtDisplay (d, xid);
 
     if (s)
-	for (w = s->windows; w; w = w->next)
-	{
-		NEG_WINDOW (w);
-		nw->isNeg = !nw->isNeg;
-		NEGUpdateState (w);
-	}
+	NEGToggleMatches (s);
 
     return TRUE;
 }

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -842,8 +842,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
-    negSetScreenToggleKeyInitiate (d, negToggleMatched);
+    negSetScreenToggleKeyInitiate  (d, negToggleAll);
+    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -175,8 +175,7 @@ NEGToggleScreen (CompScreen *s)
 	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
-    /* toggle screen negative flags */
-    ns->isNeg = !ns->isNeg;
+    /* toggle screen negative flag */
     ns->keyNegToggled = !ns->keyNegToggled;
 
     NEGUpdateScreen (s);
@@ -193,8 +192,7 @@ NEGToggleMatches (CompScreen *s)
 	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
-    /* toggle match negative flags */
-    ns->matchNeg = !ns->matchNeg;
+    /* toggle match negative flag */
     ns->keyMatchToggled = !ns->keyMatchToggled;
 
     NEGUpdateScreen (s);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -149,9 +149,12 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    if (negGetPreserveToggled (w->screen) && nw->keyNegToggled)
+    if (!negGetPreserveToggled (w->screen))
+	return;
+
+    if (nw->keyNegToggled)
 	nw->keyNegToggled = FALSE;
-    else if (negGetPreserveToggled (w->screen) && nw->keyNegPreserved)
+    else if (nw->keyNegPreserved)
 	nw->keyNegToggled = TRUE;
 }
 
@@ -689,14 +692,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    CompWindow *w;
-
-	    /* update toggle state for relevant windows */
-	    for (w = s->windows; w; w = w->next)
-		if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
-		    NEGWindowUpdateKeyToggle (w);
-
-	    ns->isNeg = opt[NegScreenOptionToggleScreenByDefault].value.b;
+	    ns->isNeg = !ns->isNeg;
 
 	    NEGUpdateScreen (s);
 	}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -607,8 +607,8 @@ NEGScreenOptionChanged (CompScreen       *s,
 {
     switch (num)
     {
-    case NegScreenOptionToggleByDefault:
-    {
+    case NegScreenOptionToggleMatchByDefault:
+	{
 		CompWindow *w;
 
 		NEG_SCREEN (s);
@@ -630,8 +630,53 @@ NEGScreenOptionChanged (CompScreen       *s,
 			}
 		}
 	}
-    break;
+	break;
+    case NegScreenOptionToggleByDefault:
+	{
+		CompWindow *w;
+
+		NEG_SCREEN (s);
+
+		ns->isNeg = opt[NegScreenOptionToggleByDefault].value.b;
+
+		for (w = s->windows; w; w = w->next)
+		{
+			NEG_WINDOW (w);
+			if (ns->isNeg)
+			{
+				if (!nw->isNeg)
+					NEGUpdateState (w);
+			}
+			else
+			{
+				if (nw->isNeg)
+					NEGUpdateState (w);
+			}
+		}
+	}
+	break;
     case NegScreenOptionNegMatch:
+	{
+	    CompWindow *w;
+	    NEG_SCREEN (s);
+
+	    for (w = s->windows; w; w = w->next)
+	    {
+			NEG_WINDOW (w);
+
+			nw->matched = matchEval (negGetNegMatch (w->screen), w);
+
+			if (nw->matched)
+			{
+				if ((ns->isNeg || negGetToggleByDefault (s)) && !nw->isNeg)
+					NEGUpdateState (w);
+			}
+			else if (nw->isNeg)
+				NEGUpdateState (w);
+	    }
+	}
+	break;
+    case NegScreenOptionExcludeMatch:
 	{
 	    CompWindow *w;
 	    NEG_SCREEN (s);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -672,7 +672,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = opt[NegScreenOptionToggleByDefault].value.b;
+	    ns->matchNeg = !ns->matchNeg;
 
 	    NEGUpdateScreen (s);
 	}
@@ -686,7 +686,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = opt[NegScreenOptionToggleScreenByDefault].value.b;
+	    ns->isNeg = !ns->isNeg;
 
 	    NEGUpdateScreen (s);
 	}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -105,6 +105,9 @@ NEGUpdateState (CompWindow *w)
     if ( ( ! negGetPreserveToggled (w->screen) ) && nw->keyNegToggled)
 	windowState = !windowState;
 
+    if ( negGetPreserveToggled (w->screen) && nw->isNeg )
+	windowState = !windowState;
+
     /* Now that we know what this window's state should be, push the value to
        its nw->isNeg. */
     nw->isNeg = windowState;
@@ -138,8 +141,7 @@ NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    if ( ! negGetPreserveToggled (w->screen) )
-	nw->keyNegToggled = !nw->keyNegToggled;
+    nw->keyNegToggled = !nw->keyNegToggled;
 
     /* cause repainting */
     NEGUpdateState (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -67,9 +67,9 @@ typedef struct _NEGWindow
                            when Preserve Toggled Windows means the window
                            should be using its previous state) */
     Bool keyNegPreserved; /* window has been individually toggled using the
-                           "Toggle Window Negative" keybinding. This preserves
-                           the window state between screen toggles for Preserve
-                           Toggled Windows. */
+                             "Toggle Window Negative" keybinding. This preserves
+                             the window state between screen toggles for Preserve
+                             Toggled Windows. */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -103,9 +103,9 @@ NEGUpdateState (CompWindow *w)
        the various parameters that can affect this, and set windowState thus */
 
     if ( ( ! matchEval (negGetExcludeMatch (w->screen), w) ) && ns->isNeg)
-	windowState = true;
+	windowState = TRUE;
     else
-	windowState = false;
+	windowState = FALSE;
 
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
 	windowState = !windowState;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -900,7 +900,6 @@ NEGInitScreen (CompPlugin *p,
     negSetToggleScreenByDefaultNotify (s, NEGScreenOptionChanged);
     negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
     negSetPreserveToggledNotify (s, NEGScreenOptionChanged);
-    negSetClearToggledNotify (s, NEGScreenOptionChanged);
 
     /* wrap overloaded functions */
     WRAP (ns, s, drawWindowTexture, NEGDrawWindowTexture);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -171,40 +171,6 @@ NEGToggleWindow (CompWindow *w)
 }
 
 static void
-NEGToggleScreen (CompScreen *s)
-{
-    NEG_SCREEN (s);
-    CompWindow *w;
-
-    /* update toggle state for relevant windows */
-    for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
-	    NEGWindowUpdateKeyToggle (w);
-
-    /* toggle screen negative flag */
-    ns->keyNegToggled = !ns->keyNegToggled;
-
-    NEGUpdateScreen (s);
-}
-
-static void
-NEGToggleMatches (CompScreen *s)
-{
-    NEG_SCREEN (s);
-    CompWindow *w;
-
-    /* update toggle state for relevant windows */
-    for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
-	    NEGWindowUpdateKeyToggle (w);
-
-    /* toggle match negative flag */
-    ns->keyMatchToggled = !ns->keyMatchToggled;
-
-    NEGUpdateScreen (s);
-}
-
-static void
 NEGScreenClearToggled (CompScreen *s)
 {
     CompWindow *w;
@@ -222,6 +188,26 @@ NEGScreenClearToggled (CompScreen *s)
 }
 
 static void
+NEGToggleScreen (CompScreen *s)
+{
+    NEG_SCREEN (s);
+    CompWindow *w;
+
+    /* update toggle state for relevant windows */
+    for (w = s->windows; w; w = w->next)
+	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
+	    NEGWindowUpdateKeyToggle (w);
+
+    /* Clear toggled window state if the Auto-Clear config option is set */
+    NEGScreenClearToggled(s);
+
+    /* toggle screen negative flag */
+    ns->keyNegToggled = !ns->keyNegToggled;
+
+    NEGUpdateScreen (s);
+}
+
+static void
 NEGMatchClearToggled (CompScreen *s)
 {
     CompWindow *w;
@@ -236,6 +222,26 @@ NEGMatchClearToggled (CompScreen *s)
 	    }
 	}
     }
+}
+
+static void
+NEGToggleMatches (CompScreen *s)
+{
+    NEG_SCREEN (s);
+    CompWindow *w;
+
+    /* update toggle state for relevant windows */
+    for (w = s->windows; w; w = w->next)
+	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
+	    NEGWindowUpdateKeyToggle (w);
+
+    /* Clear toggled window state if the Auto-Clear config option is set */
+    NEGMatchClearToggled(s);
+
+    /* toggle match negative flag */
+    ns->keyMatchToggled = !ns->keyMatchToggled;
+
+    NEGUpdateScreen (s);
 }
 
 static Bool
@@ -270,10 +276,8 @@ negToggleAll (CompDisplay     *d,
     xid = getIntOptionNamed (option, nOption, "root", 0);
     s = findScreenAtDisplay (d, xid);
 
-    if (s) {
-	NEGScreenClearToggled(s);
+    if (s)
 	NEGToggleScreen (s);
-    }
 
     return TRUE;
 }
@@ -291,10 +295,8 @@ negToggleMatched (CompDisplay     *d,
     xid = getIntOptionNamed (option, nOption, "root", 0);
     s = findScreenAtDisplay (d, xid);
 
-    if (s) {
-	NEGMatchClearToggled(s);
+    if (s)
 	NEGToggleMatches (s);
-    }
 
     return TRUE;
 }

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -155,6 +155,30 @@ negToggleAll (CompDisplay     *d,
     return TRUE;
 }
 
+static Bool
+negToggleMatched (CompDisplay     *d,
+	      CompAction      *action,
+	      CompActionState state,
+	      CompOption      *option,
+	      int             nOption)
+{
+    CompScreen *s;
+    Window     xid;
+
+    xid = getIntOptionNamed (option, nOption, "root", 0);
+    s = findScreenAtDisplay (d, xid);
+
+    if (s)
+	for (w = s->windows; w; w = w->next)
+	{
+		NEG_WINDOW (w);
+		nw->isNeg = !nw->isNeg;
+		NEGUpdateState (w);
+	}
+
+    return TRUE;
+}
+
 static int
 getNegFragmentFunction (CompScreen  *s,
 			CompTexture *texture,
@@ -704,6 +728,7 @@ NEGInitDisplay (CompPlugin  *p,
 
     negSetWindowToggleKeyInitiate (d, negToggle);
     negSetScreenToggleKeyInitiate (d, negToggleAll);
+    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 
@@ -866,4 +891,3 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
-

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -201,7 +201,7 @@ NEGToggleScreen (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
+	if (negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* Clear toggled window state if the Auto-Clear config option is set */
@@ -238,7 +238,7 @@ NEGToggleMatches (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
+	if (negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* Clear toggled window state if the Auto-Clear config option is set */

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -81,17 +81,6 @@ typedef struct _NEGWindow
 
 
 static void
-NEGToggleWindow (CompWindow *w)
-{
-    NEG_WINDOW (w);
-
-	nw->key_toggled = !nw->key_toggled;
-
-    /* cause repainting */
-    NEGUpdateState (w);
-}
-
-static void
 NEGUpdateState (CompWindow *w)
 {
     NEG_SCREEN (w->screen);
@@ -110,7 +99,7 @@ NEGUpdateState (CompWindow *w)
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
 	windowState = !windowState;
 
-    if (negGetPreserveToggled (s) && nw->key_toggled)
+    if (negGetPreserveToggled (w->screen) && nw->key_toggled)
 	windowState = !windowState;
 
     /* Now that we know what this window's state should be, push the value to
@@ -119,6 +108,17 @@ NEGUpdateState (CompWindow *w)
 
     /* cause repainting */
     addWindowDamage (w);
+}
+
+static void
+NEGToggleWindow (CompWindow *w)
+{
+    NEG_WINDOW (w);
+
+	nw->key_toggled = !nw->key_toggled;
+
+    /* cause repainting */
+    NEGUpdateState (w);
 }
 
 static void

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -781,8 +781,11 @@ NEGInitScreen (CompPlugin *p,
     ns->negFunction      = 0;
     ns->negAlphaFunction = 0;
 
-    negSetToggleByDefaultNotify (s, NEGScreenOptionChanged);
+    negSetToggleMatchByDefaultNotify (s, NEGScreenOptionChanged);
     negSetNegMatchNotify (s, NEGScreenOptionChanged);
+    negSetToggleByDefaultNotify (s, NEGScreenOptionChanged);
+    negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
+    negSetPreserveToggledNotify (s, NEGScreenOptionChanged);
 
     /* wrap overloaded functions */
     WRAP (ns, s, drawWindowTexture, NEGDrawWindowTexture);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -103,7 +103,7 @@ NEGUpdateState (CompWindow *w)
     /* Decide whether the given window should be negative or not, depending on
        the various parameters that can affect this, and set windowState thus */
 
-	windowState = FALSE;
+    windowState = FALSE;
 
     /* Whole screen toggle state */
     if (! matchEval (negGetExcludeMatch (w->screen), w)) {

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -129,7 +129,7 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    if ( negGetPreserveToggled (w->screen))
+    if ( negGetPreserveToggled (w->screen) )
 	nw->keyNegToggled = FALSE;
 }
 
@@ -138,7 +138,8 @@ NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    nw->keyNegToggled = !nw->keyNegToggled;
+    if ( ! negGetPreserveToggled (w->screen) )
+	nw->keyNegToggled = !nw->keyNegToggled;
 
     /* cause repainting */
     NEGUpdateState (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -96,7 +96,7 @@ NEGUpdateState (CompWindow *w)
     else
 	windowState = FALSE;
 
-    if (matchEval (negGetExcludeMatch (w->screen), w) && ns->keyNegToggled)
+    if ( ( ! matchEval (negGetExcludeMatch (w->screen), w) ) && ns->keyNegToggled)
 	windowState = !windowState;
 
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
@@ -125,6 +125,24 @@ NEGUpdateScreen (CompScreen *s)
 }
 
 static void
+NEGWindowUpdateKeyToggle (CompWindow *w)
+{
+    if ( negGetPreserveToggled (w->screen))
+	nw->keyNegToggled = FALSE;
+}
+
+static void
+NEGScreenUpdateKeyToggles (CompScreen *s)
+{
+    CompWindow *w;
+
+    /* update every window */
+    for (w = s->windows; w; w = w->next)
+	if (w)
+	    NEGWindowUpdateKeyToggle (w);
+}
+
+static void
 NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
@@ -139,6 +157,8 @@ static void
 NEGToggleScreen (CompScreen *s)
 {
     NEG_SCREEN (s);
+
+    NEGScreenUpdateKeyToggles (s);
 
     /* toggle screen negative flag */
     ns->keyNegToggled = !ns->keyNegToggled;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -143,12 +143,12 @@ NEGUpdateScreen (CompScreen *s)
 	NEGUpdateState (w);
 }
 
+/* NEGWindowUpdateKeyToggle: This function updates the window-toggled state
+   bools for a given window if needed for the Preserve Toggled Windows
+   option. */
 static void
 NEGWindowUpdateKeyToggle (CompWindow *w)
 {
-    /* This function updates the window-toggled state bools for a given window
-       if needed for the Preserve Toggled Windows option. */
-
     NEG_WINDOW (w);
 
     if (!negGetPreserveToggled (w->screen))
@@ -172,13 +172,12 @@ NEGToggleWindow (CompWindow *w)
     NEGUpdateState (w);
 }
 
+/* NEGScreenClearToggled: This function clears toggled window state for windows
+   in the Screen set (not matched by Screen Exclusions) if the Auto-Clear config
+   option is set. */
 static void
 NEGScreenClearToggled (CompScreen *s)
 {
-    /* This function clears toggled window state for windows in the Screen set
-       (not matched by Screen Exclusions) if the Auto-Clear config option is
-       set. */
-
     CompWindow *w;
 
     if (!negGetClearToggled (s))

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -56,7 +56,6 @@ typedef struct _NEGScreen
 typedef struct _NEGWindow
 {
     Bool isNeg; /* negative window flag */
-    Bool matched;
     Bool key_toggled; /* window has been individually toggled */
 } NEGWindow;
 
@@ -613,10 +612,7 @@ static void
 NEGWindowAdd (CompScreen *s,
 	      CompWindow *w)
 {
-	NEG_SCREEN (s);
 	NEG_WINDOW (w);
-
-	nw->matched = matchEval (negGetNegMatch (s), w);
 
 	/* Run matching logic on this window */
 	NEGUpdateState (w);
@@ -786,7 +782,8 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg = FALSE;
+    ns->isNeg    = FALSE;
+    ns->matchNeg = FALSE;
 
     ns->negFunction      = 0;
     ns->negAlphaFunction = 0;
@@ -836,7 +833,7 @@ NEGInitWindow (CompPlugin *p,
 	return FALSE;
 
     nw->isNeg       = FALSE;
-    nw->matched     = FALSE;
+    nw->key_toggled = FALSE;
 
     w->base.privates[ns->windowPrivateIndex].ptr = nw;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -96,7 +96,7 @@ NEGUpdateState (CompWindow *w)
     else
 	windowState = FALSE;
 
-    if (matchEval (negGetNegMatch (w->screen), w) && ns->keyNegToggled)
+    if (matchEval (negGetExcludeMatch (w->screen), w) && ns->keyNegToggled)
 	windowState = !windowState;
 
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -100,7 +100,7 @@ NEGUpdateState (CompWindow *w)
     if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
 	windowState = !windowState;
 
-    if (matchEval (negGetNegMatch (w->screen), w) && ! ns->matchNeg)
+    if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
 	windowState = !windowState;
 
     if (nw->keyNegToggled)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -94,7 +94,7 @@ NEGToggleWindow (CompWindow *w)
 static void
 NEGUpdateState (CompWindow *w)
 {
-    NEG_SCREEN (s);
+    NEG_SCREEN (w->screen);
     NEG_WINDOW (w);
 
     Bool windowState;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -56,6 +56,7 @@ typedef struct _NEGWindow
 {
     Bool isNeg; /* negative window flag */
     Bool matched;
+    Bool toggled; /* window has been individually toggled */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \
@@ -86,7 +87,7 @@ NEGToggleWindow (CompWindow *w)
 	nw->isNeg = !nw->isNeg;
 
     /* cause repainting */
-    addWindowDamage (w);
+    NEGUpdateState (w);
 }
 
 static void
@@ -94,11 +95,8 @@ NEGUpdateState (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    /* check include list */
-    if (matchEval (negGetNegMatch (w->screen), w))
-		NEGToggleWindow(w);
-	else
-		nw->isNeg = FALSE;
+    /* cause repainting */
+    addWindowDamage (w);
 }
 
 static void
@@ -111,10 +109,10 @@ NEGToggleScreen (CompScreen *s)
     /* toggle screen negative flag */
     ns->isNeg = !ns->isNeg;
 
-    /* toggle every window */
+    /* update every window */
     for (w = s->windows; w; w = w->next)
 	if (w)
-	    NEGToggleWindow (w);
+	    NEGUpdateState (w);
 }
 
 static void
@@ -124,7 +122,7 @@ NEGToggleMatches (CompScreen *s)
 
     NEG_SCREEN(s);
 
-    /* toggle matched windows */
+    /* update every window */
     for (w = s->windows; w; w = w->next)
 	if (w)
 	    NEGUpdateState (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -179,17 +179,17 @@ NEGScreenClearToggled (CompScreen *s)
        (not matched by Screen Exclusions) if the Auto-Clear config option is
        set. */
 
+    CompWindow *w;
+
     if (!negGetClearToggled (s))
 	return;
-
-    CompWindow *w;
 
     for (w = s->windows; w; w = w->next)
     {
 	if (! matchEval (negGetExcludeMatch (w->screen), w)) {
-    	NEG_WINDOW (w);
-    	nw->keyNegToggled = FALSE;
-    	nw->keyNegPreserved = FALSE;
+	    NEG_WINDOW (w);
+	    nw->keyNegToggled = FALSE;
+	    nw->keyNegPreserved = FALSE;
 	}
     }
 }
@@ -219,14 +219,15 @@ NEGMatchClearToggled (CompScreen *s)
 {
     CompWindow *w;
 
-    if (negGetClearToggled (s)) {
-	for (w = s->windows; w; w = w->next)
-	{
-	    if (matchEval (negGetNegMatch (w->screen), w)) {
-		NEG_WINDOW (w);
-		nw->keyNegToggled = FALSE;
-		nw->keyNegPreserved = FALSE;
-	    }
+    if (!negGetClearToggled (s))
+	return;
+
+    for (w = s->windows; w; w = w->next)
+    {
+	if (matchEval (negGetNegMatch (w->screen), w)) {
+	    NEG_WINDOW (w);
+	    nw->keyNegToggled = FALSE;
+	    nw->keyNegPreserved = FALSE;
 	}
     }
 }
@@ -501,12 +502,12 @@ NEGDrawWindowTexture (CompWindow           *w,
 		    glTexEnvf (GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PREVIOUS);
 		    glTexEnvf (GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
 
-    		    /* color constant */
+		    /* color constant */
 		    constant[3] = attrib->saturation / 65535.0f;
 
 		    glTexEnvfv (GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, constant);
 
-    		    /* if we are not opaque or not fully bright */
+		    /* if we are not opaque or not fully bright */
 		    if (attrib->opacity < OPAQUE ||
 			attrib->brightness != BRIGHT)
 		    {

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -152,7 +152,7 @@ NEGToggleScreen (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (w)))
+	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s)))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle screen negative flag */
@@ -169,7 +169,7 @@ NEGToggleMatches (CompScreen *s)
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (w)))
+	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s)))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle match negative flag */

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -135,10 +135,9 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 
     if (negGetPreserveToggled (w->screen) && nw->keyNegToggled)
 	nw->keyNegToggled = FALSE;
-	nw->keyNegPreserved = TRUE;
-    if (negGetPreserveToggled (w->screen) && nw->keyNegPreserved)
+    else if (negGetPreserveToggled (w->screen) && nw->keyNegPreserved)
 	nw->keyNegToggled = TRUE;
-    nw->keyNegPreserved = FALSE;
+	nw->keyNegPreserved = FALSE;
 }
 
 static void
@@ -147,6 +146,7 @@ NEGToggleWindow (CompWindow *w)
     NEG_WINDOW (w);
 
     nw->keyNegToggled = !nw->keyNegToggled;
+    nw->keyNegPreserved = !nw->keyNegPreserved;
 
     /* cause repainting */
     NEGUpdateState (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -62,6 +62,9 @@ typedef struct _NEGWindow
     Bool isNeg; /* negative window flag: controlled by NEGUpdateState function */
     Bool keyNegToggled; /* window has been individually toggled using the
                            "Toggle Window Negative" keybinding */
+    Bool keyNegPreserved; /* window has been individually toggled using the
+                           "Toggle Window Negative" keybinding, but it is not
+                           active at the moment */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \
@@ -132,6 +135,10 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 
     if (negGetPreserveToggled (w->screen) && nw->keyNegToggled)
 	nw->keyNegToggled = FALSE;
+	nw->keyNegPreserved = TRUE;
+    if (negGetPreserveToggled (w->screen) && nw->keyNegPreserved)
+	nw->keyNegToggled = TRUE;
+    nw->keyNegPreserved = FALSE;
 }
 
 static void
@@ -856,8 +863,9 @@ NEGInitWindow (CompPlugin *p,
     if (!nw)
 	return FALSE;
 
-    nw->isNeg         = FALSE;
-    nw->keyNegToggled = FALSE;
+    nw->isNeg           = FALSE;
+    nw->keyNegToggled   = FALSE;
+    nw->keyNegPreserved = FALSE;
 
     w->base.privates[ns->windowPrivateIndex].ptr = nw;
 
@@ -933,4 +941,3 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
-

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -764,8 +764,8 @@ NEGInitDisplay (CompPlugin  *p,
 	return FALSE;
     }
 
-    negSetWindowToggleKeyInitiate (d, negToggle);
-    negSetScreenToggleKeyInitiate (d, negToggleAll);
+    negSetWindowToggleKeyInitiate  (d, negToggle);
+    negSetScreenToggleKeyInitiate  (d, negToggleAll);
     negSetMatchedToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
@@ -933,4 +933,3 @@ getCompPluginInfo(void)
 {
     return &NEGVTable;
 }
-

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -884,12 +884,9 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg           = FALSE; /* This must be kept in sync with default
-                                    toggle_screen_by_default value from
-                                    neg.xml.in. */
+    ns->isNeg           = FALSE;
     ns->keyNegToggled   = FALSE;
-    ns->matchNeg        = FALSE; /* This must be kept in sync with default
-                                    toggle_by_default value from neg.xml.in. */
+    ns->matchNeg        = FALSE;
     ns->keyMatchToggled = FALSE;
 
     ns->negFunction      = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -127,6 +127,8 @@ NEGUpdateScreen (CompScreen *s)
 static void
 NEGWindowUpdateKeyToggle (CompWindow *w)
 {
+    NEG_WINDOW (w);
+
     if ( negGetPreserveToggled (w->screen))
 	nw->keyNegToggled = FALSE;
 }
@@ -146,10 +148,11 @@ static void
 NEGToggleScreen (CompScreen *s)
 {
     NEG_SCREEN (s);
+    CompWindow *w;
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (w))
+	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (w)))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle screen negative flag */
@@ -162,10 +165,11 @@ static void
 NEGToggleMatches (CompScreen *s)
 {
     NEG_SCREEN (s);
+    CompWindow *w;
 
     /* update toggle state for relevant windows */
     for (w = s->windows; w; w = w->next)
-	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (w))
+	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (w)))
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle match negative flag */

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -147,6 +147,9 @@ NEGUpdateScreen (CompScreen *s)
 static void
 NEGWindowUpdateKeyToggle (CompWindow *w)
 {
+    /* This function updates the window-toggled state bools for a given window
+       if needed for the Preserve Toggled Windows option. */
+
     NEG_WINDOW (w);
 
     if (!negGetPreserveToggled (w->screen))
@@ -173,6 +176,10 @@ NEGToggleWindow (CompWindow *w)
 static void
 NEGScreenClearToggled (CompScreen *s)
 {
+    /* This function clears toggled window state for windows in the Screen set
+       (not matched by Screen Exclusions) if the Auto-Clear config option is
+       set. */
+
     CompWindow *w;
 
     if (negGetClearToggled (s)) {
@@ -718,7 +725,9 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
+	    /* Clear toggled window state if the Auto-Clear config option is set */
 	    NEGMatchClearToggled(s);
+
 	    ns->matchNeg = negGetToggleByDefault (s);
 
 	    NEGUpdateScreen (s);
@@ -733,7 +742,9 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
+	    /* Clear toggled window state if the Auto-Clear config option is set */
 	    NEGScreenClearToggled(s);
+
 	    ns->isNeg = negGetToggleScreenByDefault (s);
 
 	    NEGUpdateScreen (s);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -46,9 +46,13 @@ typedef struct _NEGScreen
 
     DrawWindowTextureProc drawWindowTexture;
 
-    Bool isNeg; /* negative screen flag */
-    Bool matchNeg; /* match group is toggled */
-    Bool keyNegToggled; /* screen has been individually toggled */
+    Bool isNeg; /* negative screen flag: controlled by "Auto-Toggle Screen"
+                   checkbox */
+    Bool matchNeg; /* match group is toggled: controlled by "Auto-Toggle
+                      Matched Windows" checkbox, or toggled using the "Toggle
+                      Matched Windows Negative keybinding" */
+    Bool keyNegToggled; /* screen has been individually toggled using the
+                           "Toggle Screen Negative" keybinding */
 
     int negFunction;
     int negAlphaFunction;
@@ -56,8 +60,9 @@ typedef struct _NEGScreen
 
 typedef struct _NEGWindow
 {
-    Bool isNeg; /* negative window flag */
-    Bool keyNegToggled; /* window has been individually toggled */
+    Bool isNeg; /* negative window flag: controlled by NEGUpdateState function */
+    Bool keyNegToggled; /* window has been individually toggled using the
+                           "Toggle Window Negative" keybinding */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \
@@ -91,10 +96,10 @@ NEGUpdateState (CompWindow *w)
     /* Decide whether the given window should be negative or not, depending on
        the various parameters that can affect this, and set windowState thus */
 
-    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
-	windowState = TRUE;
-    else
 	windowState = FALSE;
+
+    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
+	windowState = !windowState;
 
     if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->keyNegToggled)
 	windowState = !windowState;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -884,12 +884,12 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg           = FALSE; /* Keep in sync with default
+    ns->isNeg           = FALSE; /* This must be kept in sync with default
                                     toggle_screen_by_default value from
-                                    neg.xml.in */
+                                    neg.xml.in. */
     ns->keyNegToggled   = FALSE;
-    ns->matchNeg        = FALSE; /* Keep in sync with default toggle_by_default
-                                    value from neg.xml.in */
+    ns->matchNeg        = FALSE; /* This must be kept in sync with default
+                                    toggle_by_default value from neg.xml.in. */
     ns->keyMatchToggled = FALSE;
 
     ns->negFunction      = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -844,8 +844,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
-    negSetScreenToggleKeyInitiate (d, negToggleMatched);
+    negSetScreenToggleKeyInitiate  (d, negToggleAll);
+    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -649,7 +649,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 {
     switch (num)
     {
-    case NegScreenOptionToggleMatchByDefault:
+    case NegScreenOptionToggleByDefault:
 	{
 	    NEG_SCREEN (s);
 
@@ -663,7 +663,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	    NEGUpdateScreen (s);
 	}
 	break;
-    case NegScreenOptionToggleByDefault:
+    case NegScreenOptionToggleScreenByDefault:
 	{
 	    NEG_SCREEN (s);
 
@@ -812,9 +812,9 @@ NEGInitScreen (CompPlugin *p,
     ns->negFunction      = 0;
     ns->negAlphaFunction = 0;
 
-    negSetToggleMatchByDefaultNotify (s, NEGScreenOptionChanged);
-    negSetNegMatchNotify (s, NEGScreenOptionChanged);
     negSetToggleByDefaultNotify (s, NEGScreenOptionChanged);
+    negSetNegMatchNotify (s, NEGScreenOptionChanged);
+    negSetToggleScreenByDefaultNotify (s, NEGScreenOptionChanged);
     negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
     negSetPreserveToggledNotify (s, NEGScreenOptionChanged);
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -79,18 +79,26 @@ typedef struct _NEGWindow
 
 
 static void
+NEGToggleWindow (CompWindow *w)
+{
+    NEG_WINDOW (w);
+
+	nw->isNeg = !nw->isNeg;
+
+    /* cause repainting */
+    addWindowDamage (w);
+}
+
+static void
 NEGUpdateState (CompWindow *w)
 {
     NEG_WINDOW (w);
 
     /* check include list */
     if (matchEval (negGetNegMatch (w->screen), w))
-		nw->isNeg = !nw->isNeg;
+		NEGToggleWindow(w);
 	else
 		nw->isNeg = FALSE;
-
-    /* cause repainting */
-    addWindowDamage (w);
 }
 
 static void
@@ -106,7 +114,7 @@ NEGToggleScreen (CompScreen *s)
     /* toggle every window */
     for (w = s->windows; w; w = w->next)
 	if (w)
-	    NEGUpdateState (w);
+	    NEGToggleWindow (w);
 }
 
 static Bool
@@ -123,7 +131,7 @@ negToggle (CompDisplay     *d,
     w = findWindowAtDisplay (d, xid);
 
     if (w)
-	NEGUpdateState (w);
+	NEGToggleWindow (w);
 
     return TRUE;
 }

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -98,7 +98,7 @@ NEGUpdateState (CompWindow *w)
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
 	windowState = !windowState;
 
-    if (negGetPreserveToggled (w->screen) && nw->key_toggled)
+    if ( ( ! negGetPreserveToggled (w->screen) ) && nw->key_toggled)
 	windowState = !windowState;
 
     /* Now that we know what this window's state should be, push the value to
@@ -114,7 +114,8 @@ NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-	nw->key_toggled = !nw->key_toggled;
+    nw->isNeg = TRUE;
+    nw->key_toggled = !nw->key_toggled;
 
     /* cause repainting */
     NEGUpdateState (w);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -204,6 +204,40 @@ NEGToggleMatches (CompScreen *s)
     NEGUpdateScreen (s);
 }
 
+static void
+NEGScreenClearToggled (CompScreen *s)
+{
+    CompWindow *w;
+
+    if (negGetClearToggled (s)) {
+	for (w = s->windows; w; w = w->next)
+	{
+	    if (! matchEval (negGetExcludeMatch (w->screen), w)) {
+		NEG_WINDOW (w);
+		nw->keyNegToggled = FALSE;
+		nw->keyNegPreserved = FALSE;
+	    }
+	}
+    }
+}
+
+static void
+NEGMatchClearToggled (CompScreen *s)
+{
+    CompWindow *w;
+
+    if (negGetClearToggled (s)) {
+	for (w = s->windows; w; w = w->next)
+	{
+	    if (matchEval (negGetNegMatch (w->screen), w)) {
+		NEG_WINDOW (w);
+		nw->keyNegToggled = FALSE;
+		nw->keyNegPreserved = FALSE;
+	    }
+	}
+    }
+}
+
 static Bool
 negToggle (CompDisplay     *d,
 	   CompAction      *action,
@@ -236,8 +270,10 @@ negToggleAll (CompDisplay     *d,
     xid = getIntOptionNamed (option, nOption, "root", 0);
     s = findScreenAtDisplay (d, xid);
 
-    if (s)
+    if (s) {
+	NEGScreenClearToggled(s);
 	NEGToggleScreen (s);
+    }
 
     return TRUE;
 }
@@ -255,8 +291,10 @@ negToggleMatched (CompDisplay     *d,
     xid = getIntOptionNamed (option, nOption, "root", 0);
     s = findScreenAtDisplay (d, xid);
 
-    if (s)
+    if (s) {
+	NEGMatchClearToggled(s);
 	NEGToggleMatches (s);
+    }
 
     return TRUE;
 }
@@ -677,19 +715,8 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleByDefault:
 	{
 	    NEG_SCREEN (s);
-	    CompWindow *w;
 
-	    if (negGetClearToggled (s)) {
-		for (w = s->windows; w; w = w->next)
-		{
-		    if (matchEval (negGetNegMatch (w->screen), w)) {
-			NEG_WINDOW (w);
-			nw->keyNegToggled = FALSE;
-			nw->keyNegPreserved = FALSE;
-		    }
-		}
-	    }
-
+	    NEGMatchClearToggled(s);
 	    ns->matchNeg = negGetToggleByDefault (s);
 
 	    NEGUpdateScreen (s);
@@ -703,19 +730,8 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleScreenByDefault:
 	{
 	    NEG_SCREEN (s);
-	    CompWindow *w;
 
-	    if (negGetClearToggled (s)) {
-		for (w = s->windows; w; w = w->next)
-		{
-		    if (! matchEval (negGetExcludeMatch (w->screen), w)) {
-			NEG_WINDOW (w);
-			nw->keyNegToggled = FALSE;
-			nw->keyNegPreserved = FALSE;
-		    }
-		}
-	    }
-
+	    NEGScreenClearToggled(s);
 	    ns->isNeg = negGetToggleScreenByDefault (s);
 
 	    NEGUpdateScreen (s);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -132,17 +132,6 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 }
 
 static void
-NEGScreenUpdateKeyToggles (CompScreen *s)
-{
-    CompWindow *w;
-
-    /* update every window */
-    for (w = s->windows; w; w = w->next)
-	if (w)
-	    NEGWindowUpdateKeyToggle (w);
-}
-
-static void
 NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
@@ -158,7 +147,10 @@ NEGToggleScreen (CompScreen *s)
 {
     NEG_SCREEN (s);
 
-    NEGScreenUpdateKeyToggles (s);
+    /* update toggle state for relevant windows */
+    for (w = s->windows; w; w = w->next)
+	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (w))
+	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle screen negative flag */
     ns->keyNegToggled = !ns->keyNegToggled;
@@ -170,6 +162,11 @@ static void
 NEGToggleMatches (CompScreen *s)
 {
     NEG_SCREEN (s);
+
+    /* update toggle state for relevant windows */
+    for (w = s->windows; w; w = w->next)
+	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (w))
+	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle match negative flag */
     ns->matchNeg = !ns->matchNeg;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -842,8 +842,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetScreenToggleKeyInitiate  (d, negToggleAll);
-    negSetMatchedToggleKeyInitiate (d, negToggleMatched);
+    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
+    negSetScreenToggleKeyInitiate (d, negToggleMatched);
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -653,7 +653,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = opt[NegScreenOptionToggleMatchByDefault].value.b;
+	    ns->matchNeg = !ns->matchNeg;
 
 	    NEGUpdateScreen (s);
 	}
@@ -667,7 +667,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = opt[NegScreenOptionToggleByDefault].value.b;
+	    ns->isNeg = !ns->isNeg;
 
 	    NEGUpdateScreen (s);
 	}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -57,7 +57,7 @@ typedef struct _NEGWindow
 {
     Bool isNeg; /* negative window flag */
     Bool matched;
-    Bool toggled; /* window has been individually toggled */
+    Bool key_toggled; /* window has been individually toggled */
 } NEGWindow;
 
 #define GET_NEG_CORE(c) \
@@ -85,7 +85,7 @@ NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-	nw->toggled = !nw->toggled;
+	nw->key_toggled = !nw->key_toggled;
 
     /* cause repainting */
     NEGUpdateState (w);
@@ -102,7 +102,16 @@ NEGUpdateState (CompWindow *w)
     /* Decide whether the given window should be negative or not, depending on
        the various parameters that can affect this, and set windowState thus */
 
-    windowState = ns->isNeg;
+    if ( ( ! matchEval (negGetExcludeMatch (w->screen), w) ) && ns->isNeg)
+	windowState = true;
+    else
+	windowState = false;
+
+    if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
+	windowState = !windowState;
+
+    if (negGetPreserveToggled (s) && nw->key_toggled)
+	windowState = !windowState;
 
     /* Now that we know what this window's state should be, push the value to
        its nw->isNeg. */
@@ -622,6 +631,10 @@ NEGScreenOptionChanged (CompScreen       *s,
     {
     case NegScreenOptionToggleMatchByDefault:
 	{
+	    NEG_SCREEN (s);
+
+	    ns->matchNeg = TRUE;
+
 	    NEGUpdateScreen (s);
 	}
 	break;
@@ -632,6 +645,10 @@ NEGScreenOptionChanged (CompScreen       *s,
 	break;
     case NegScreenOptionToggleByDefault:
 	{
+	    NEG_SCREEN (s);
+
+	    ns->isNeg = TRUE;
+
 	    NEGUpdateScreen (s);
 	}
 	break;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -678,7 +678,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = opt[NegScreenOptionToggleByDefault].value.b;
+	    ns->matchNeg = negGetToggleByDefault (s);
 
 	    NEGUpdateScreen (s);
 	}
@@ -692,7 +692,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = !ns->isNeg;
+	    ns->isNeg = negGetToggleScreenByDefault (s);
 
 	    NEGUpdateScreen (s);
 	}
@@ -847,6 +847,7 @@ NEGInitScreen (CompPlugin *p,
     negSetToggleScreenByDefaultNotify (s, NEGScreenOptionChanged);
     negSetExcludeMatchNotify (s, NEGScreenOptionChanged);
     negSetPreserveToggledNotify (s, NEGScreenOptionChanged);
+    negSetClearToggledNotify (s, NEGScreenOptionChanged);
 
     /* wrap overloaded functions */
     WRAP (ns, s, drawWindowTexture, NEGDrawWindowTexture);

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -47,12 +47,11 @@ typedef struct _NEGScreen
     DrawWindowTextureProc drawWindowTexture;
 
     Bool isNeg; /* negative screen flag: controlled by "Auto-Toggle Screen"
-                   checkbox */
+                   checkbox, or toggled using the "Toggle Screen Negative"
+                   keybinding */
     Bool matchNeg; /* match group is toggled: controlled by "Auto-Toggle
                       Matched Windows" checkbox, or toggled using the "Toggle
                       Matched Windows Negative keybinding" */
-    Bool keyNegToggled; /* screen has been individually toggled using the
-                           "Toggle Screen Negative" keybinding */
 
     int negFunction;
     int negAlphaFunction;
@@ -99,9 +98,6 @@ NEGUpdateState (CompWindow *w)
 	windowState = FALSE;
 
     if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
-	windowState = !windowState;
-
-    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->keyNegToggled)
 	windowState = !windowState;
 
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
@@ -161,7 +157,7 @@ NEGToggleScreen (CompScreen *s)
 	    NEGWindowUpdateKeyToggle (w);
 
     /* toggle screen negative flag */
-    ns->keyNegToggled = !ns->keyNegToggled;
+    ns->isNeg = !ns->isNeg;
 
     NEGUpdateScreen (s);
 }
@@ -810,9 +806,8 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg         = FALSE;
-    ns->matchNeg      = FALSE;
-    ns->keyNegToggled = FALSE;
+    ns->isNeg    = FALSE;
+    ns->matchNeg = FALSE;
 
     ns->negFunction      = 0;
     ns->negAlphaFunction = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -686,7 +686,12 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = !ns->isNeg;
+	    /* update toggle state for relevant windows */
+	    for (w = s->windows; w; w = w->next)
+		if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
+		    NEGWindowUpdateKeyToggle (w);
+
+	    ns->isNeg = opt[NegScreenOptionToggleScreenByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -100,7 +100,7 @@ NEGUpdateState (CompWindow *w)
     if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
 	windowState = !windowState;
 
-    if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
+    if (matchEval (negGetNegMatch (w->screen), w) && ! ns->matchNeg)
 	windowState = !windowState;
 
     if (nw->keyNegToggled)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -47,11 +47,13 @@ typedef struct _NEGScreen
     DrawWindowTextureProc drawWindowTexture;
 
     Bool isNeg; /* negative screen flag: controlled by "Auto-Toggle Screen"
-                   checkbox, or toggled using the "Toggle Screen Negative"
-                   keybinding */
+                   checkbox */
+    Bool keyNegToggled; /* screen is toggled using the "Toggle Screen Negative"
+                           keybinding */
     Bool matchNeg; /* match group is toggled: controlled by "Auto-Toggle
-                      Matched Windows" checkbox, or toggled using the "Toggle
-                      Matched Windows Negative keybinding" */
+                      Matched Windows" checkbox */
+    Bool keyMatchToggled; /* match group is toggled using the "Toggle Matched
+                             Windows Negative" keybinding */
 
     int negFunction;
     int negAlphaFunction;
@@ -812,8 +814,10 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg    = FALSE;
-    ns->matchNeg = FALSE;
+    ns->isNeg           = FALSE;
+    ns->keyNegToggled   = FALSE;
+    ns->matchNeg        = FALSE;
+    ns->keyMatchToggled = FALSE;
 
     ns->negFunction      = 0;
     ns->negAlphaFunction = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -703,6 +703,7 @@ NEGScreenOptionChanged (CompScreen       *s,
     case NegScreenOptionToggleScreenByDefault:
 	{
 	    NEG_SCREEN (s);
+	    CompWindow *w;
 
 	    if (negGetClearToggled (s)) {
 		for (w = s->windows; w; w = w->next)

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -842,8 +842,8 @@ NEGInitDisplay (CompPlugin  *p,
     }
 
     negSetWindowToggleKeyInitiate  (d, negToggle);
-    negSetNewScreenToggleKeyInitiate  (d, negToggleAll);
-    negSetScreenToggleKeyInitiate (d, negToggleMatched);
+    negSetNewScreenToggleKeyInitiate  (d, negToggleAll); /* "Toggle Screen Negative" in CCSM */
+    negSetScreenToggleKeyInitiate (d, negToggleMatched); /* "Toggle Matched Windows Negative" in CCSM */
 
     d->base.privates[displayPrivateIndex].ptr = nd;
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -85,7 +85,7 @@ NEGToggleWindow (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-	nw->isNeg = !nw->isNeg;
+	nw->toggled = !nw->toggled;
 
     /* cause repainting */
     NEGUpdateState (w);
@@ -94,8 +94,11 @@ NEGToggleWindow (CompWindow *w)
 static void
 NEGUpdateState (CompWindow *w)
 {
-    NEG_SCREEN(s);
+    NEG_SCREEN (s);
     NEG_WINDOW (w);
+
+    /* Decide whether the given window should be negative or not, depending on
+       the various parameters that can affect this, and set nw->isNeg thus */
 
     /* cause repainting */
     addWindowDamage (w);
@@ -115,7 +118,7 @@ NEGUpdateScreen (CompScreen *s)
 static void
 NEGToggleScreen (CompScreen *s)
 {
-    NEG_SCREEN(s);
+    NEG_SCREEN (s);
 
     /* toggle screen negative flag */
     ns->isNeg = !ns->isNeg;
@@ -126,7 +129,7 @@ NEGToggleScreen (CompScreen *s)
 static void
 NEGToggleMatches (CompScreen *s)
 {
-    NEG_SCREEN(s);
+    NEG_SCREEN (s);
 
     /* toggle match negative flag */
     ns->matchNeg = !ns->matchNeg;
@@ -611,27 +614,27 @@ NEGScreenOptionChanged (CompScreen       *s,
     {
     case NegScreenOptionToggleMatchByDefault:
 	{
-	    NEGUpdateScreen(s);
+	    NEGUpdateScreen (s);
 	}
 	break;
     case NegScreenOptionNegMatch:
 	{
-	    NEGUpdateScreen(s);
+	    NEGUpdateScreen (s);
 	}
 	break;
     case NegScreenOptionToggleByDefault:
 	{
-	    NEGUpdateScreen(s);
+	    NEGUpdateScreen (s);
 	}
 	break;
     case NegScreenOptionExcludeMatch:
 	{
-	    NEGUpdateScreen(s);
+	    NEGUpdateScreen (s);
 	}
 	break;
     case NegScreenOptionPreserveToggled:
 	{
-	    NEGUpdateScreen(s);
+	    NEGUpdateScreen (s);
 	}
 	break;
     default:

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -164,8 +164,9 @@ NEGToggleScreen (CompScreen *s)
 	if (w && negGetPreserveToggled (s) && ! matchEval (negGetExcludeMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
-    /* toggle screen negative flag */
+    /* toggle screen negative flags */
     ns->isNeg = !ns->isNeg;
+    ns->keyNegToggled = !ns->keyNegToggled;
 
     NEGUpdateScreen (s);
 }
@@ -181,8 +182,9 @@ NEGToggleMatches (CompScreen *s)
 	if (w && negGetPreserveToggled (s) && matchEval (negGetNegMatch (s), w))
 	    NEGWindowUpdateKeyToggle (w);
 
-    /* toggle match negative flag */
+    /* toggle match negative flags */
     ns->matchNeg = !ns->matchNeg;
+    ns->keyMatchToggled = !ns->keyMatchToggled;
 
     NEGUpdateScreen (s);
 }
@@ -661,7 +663,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = !ns->matchNeg;
+	    ns->matchNeg = opt[NegScreenOptionToggleByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}
@@ -675,7 +677,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->isNeg = !ns->isNeg;
+	    ns->isNeg = opt[NegScreenOptionToggleScreenByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}
@@ -814,9 +816,12 @@ NEGInitScreen (CompPlugin *p,
     /* initialize the screen variables
      * you know what happens if you don't
      */
-    ns->isNeg           = FALSE;
+    ns->isNeg           = FALSE; /* Keep in sync with default
+                                    toggle_screen_by_default value from
+                                    neg.xml.in */
     ns->keyNegToggled   = FALSE;
-    ns->matchNeg        = FALSE;
+    ns->matchNeg        = FALSE; /* Keep in sync with default toggle_by_default
+                                    value from neg.xml.in */
     ns->keyMatchToggled = FALSE;
 
     ns->negFunction      = 0;

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -140,8 +140,7 @@ NEGUpdateScreen (CompScreen *s)
 
     /* update every window */
     for (w = s->windows; w; w = w->next)
-	if (w)
-	    NEGUpdateState (w);
+	NEGUpdateState (w);
 }
 
 static void

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -91,21 +91,18 @@ NEGUpdateState (CompWindow *w)
     /* Decide whether the given window should be negative or not, depending on
        the various parameters that can affect this, and set windowState thus */
 
-    if ( ( ! matchEval (negGetExcludeMatch (w->screen), w) ) && ns->isNeg)
+    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->isNeg)
 	windowState = TRUE;
     else
 	windowState = FALSE;
 
-    if ( ( ! matchEval (negGetExcludeMatch (w->screen), w) ) && ns->keyNegToggled)
+    if ((! matchEval (negGetExcludeMatch (w->screen), w)) && ns->keyNegToggled)
 	windowState = !windowState;
 
     if (matchEval (negGetNegMatch (w->screen), w) && ns->matchNeg)
 	windowState = !windowState;
 
-    if ( ( ! negGetPreserveToggled (w->screen) ) && nw->keyNegToggled)
-	windowState = !windowState;
-
-    if ( negGetPreserveToggled (w->screen) && nw->isNeg )
+    if (nw->keyNegToggled)
 	windowState = !windowState;
 
     /* Now that we know what this window's state should be, push the value to
@@ -132,7 +129,7 @@ NEGWindowUpdateKeyToggle (CompWindow *w)
 {
     NEG_WINDOW (w);
 
-    if ( negGetPreserveToggled (w->screen) )
+    if (negGetPreserveToggled (w->screen) && nw->keyNegToggled)
 	nw->keyNegToggled = FALSE;
 }
 

--- a/src/neg/neg.c
+++ b/src/neg/neg.c
@@ -672,7 +672,7 @@ NEGScreenOptionChanged (CompScreen       *s,
 	{
 	    NEG_SCREEN (s);
 
-	    ns->matchNeg = !ns->matchNeg;
+	    ns->matchNeg = opt[NegScreenOptionToggleByDefault].value.b;
 
 	    NEGUpdateScreen (s);
 	}


### PR DESCRIPTION
This PR adds one bug fix and three new features.

The bug fix is that it includes @soreau's fix to always allow toggling windows.

The first new feature is Auto-Toggle Screen (with its associated exclusion match field). This checkbox, when checked, will put the entire screen into a negated state, excluding any windows listed in its exclusion match field.

The second new feature is Preserve Toggled Windows. This checkbox, when checked, will preserve the windows' state when using general toggles (Matched Windows or Screen).

The third new feature is a checkbox for Auto-Clear Toggled Window State. This checkbox is checked by default, but can be unchecked to have toggling a match group invert matched windows that are already inverted a second time, resulting in them being non-negated.

This PR also fixes some whitespace errors in `NEGDrawWindowTexture` and removes the second newline at the end of the file.